### PR TITLE
fix: Image Resolution in SSR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-md-to-html",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-md-to-html",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-md-to-html",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-md-to-html",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-md-to-html",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Vite Plugin to load markdown files as plain HTML",
   "main": "./plugin/index.js",
   "types": "./plugin/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-md-to-html",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Vite Plugin to load markdown files as plain HTML",
   "main": "./plugin/index.js",
   "types": "./plugin/index.d.ts",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -33,8 +33,12 @@ const getAssetImports = (html) => {
 };
 
 const createJSExports = ({ html, attributes, importDeclarations }) => {
+  const clientSideImageImportScript = `<script type="module">${importDeclarations.replace(
+    /import.*?from/g,
+    "import" // Turning `import xyz from './file.svg';` statements to `import './file.svg'` statements
+  )}</script>`;
   const htmlExport = importDeclarations
-    ? `export const html = \`${html}\`;`
+    ? `export const html = \`${clientSideImageImportScript}${html}\`;`
     : `export const html = ${JSON.stringify(html)}`;
   const jsSrc = `${importDeclarations}
 export const attributes = ${JSON.stringify(attributes)};

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -42,10 +42,10 @@ const createJSExports = ({
     ? `export const html = \`${clientSideImageImportScript}${html}\`;`
     : `export const html = ${JSON.stringify(html)}`;
   const jsSrc = `${importDeclarations}
- export const attributes = ${JSON.stringify(attributes)};
- ${htmlExport}
- export default html;
- `;
+export const attributes = ${JSON.stringify(attributes)};
+${htmlExport}
+export default html;
+`;
 
   return jsSrc;
 };

--- a/plugin/plugin.spec.ts
+++ b/plugin/plugin.spec.ts
@@ -1,6 +1,17 @@
+import path from "path";
 import { vitePluginMdToHTML } from "./index";
 import { describe, expect, test } from "vitest";
 import { default as d } from "dedent";
+
+/**
+ * Removes the absolute links from snapshot.
+ *
+ * We don't want to add `/Users/saurabh.daware/` kind of URL in snapshot since it might be different in everyone's machine
+ */
+const removeAbsLinks = (codeString: string): string => {
+  // @ts-ignore: too lazy to add tsconfig.json to this project.
+  return codeString.replaceAll(path.resolve("."), ".");
+};
 
 describe("plugin.transform()", () => {
   test("should add expected exports", () => {
@@ -79,14 +90,14 @@ describe("plugin.transform()", () => {
     });
 
     pluginWithResolves.configResolved({ build: { ssr: true } });
-    expect(pluginWithResolves.transform(mdSource, mdPath).code)
+    expect(removeAbsLinks(pluginWithResolves.transform(mdSource, mdPath).code))
       .toMatchInlineSnapshot(`
-        "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
-        import mdLink1 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/hello.jpeg?url\\";
+        "import mdLink0 from \\"./example.png?url\\";
+        import mdLink1 from \\"./hello.jpeg?url\\";
         
         export const attributes = {};
-        export const html = \`<script type=\\"module\\">import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
-        import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/hello.jpeg?url\\";
+        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
+        import \\"./hello.jpeg?url\\";
         </script><h2>Hello</h2>
         <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
         <img alt=\\"hello\\" src=\\"\${mdLink1}\\" />\`;
@@ -125,12 +136,12 @@ describe("plugin.transform()", () => {
     });
 
     pluginWithResolves.configResolved({ build: { ssr: true } });
-    expect(pluginWithResolves.transform(mdSource, mdPath).code)
+    expect(removeAbsLinks(pluginWithResolves.transform(mdSource, mdPath).code))
       .toMatchInlineSnapshot(`
-        "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
+        "import mdLink0 from \\"./example.png?url\\";
         
         export const attributes = {};
-        export const html = \`<script type=\\"module\\">import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
+        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
         </script><h2>Hello</h2>
         <p><img src=\\"https://hello.com/example.png\\" alt=\\"example\\">
         <img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
@@ -153,17 +164,16 @@ describe("plugin.transform()", () => {
     });
 
     pluginWithResolves.configResolved({ build: { ssr: false } });
-    expect(
-      pluginWithResolves.transform(mdSource, mdPath).code
-    ).toMatchInlineSnapshot(`
-      "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
-      
-      export const attributes = {};
-      export const html = \`<h2>Hello</h2>
-      <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
-      \`;
-      export default html;
-      "
-    `);
+    expect(removeAbsLinks(pluginWithResolves.transform(mdSource, mdPath).code))
+      .toMatchInlineSnapshot(`
+        "import mdLink0 from \\"./example.png?url\\";
+        
+        export const attributes = {};
+        export const html = \`<h2>Hello</h2>
+        <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
+        \`;
+        export default html;
+        "
+      `);
   });
 });

--- a/plugin/plugin.spec.ts
+++ b/plugin/plugin.spec.ts
@@ -78,6 +78,7 @@ describe("plugin.transform()", () => {
       resolveImageLinks: true,
     });
 
+    pluginWithResolves.configResolved({ build: { ssr: true } });
     expect(pluginWithResolves.transform(mdSource, mdPath).code)
       .toMatchInlineSnapshot(`
         "import mdLink0 from \\"./example.png?url\\";
@@ -123,6 +124,7 @@ describe("plugin.transform()", () => {
       resolveImageLinks: true,
     });
 
+    pluginWithResolves.configResolved({ build: { ssr: true } });
     expect(pluginWithResolves.transform(mdSource, mdPath).code)
       .toMatchInlineSnapshot(`
         "import mdLink0 from \\"./example.png?url\\";
@@ -136,5 +138,32 @@ describe("plugin.transform()", () => {
         export default html;
         "
       `);
+  });
+
+  test("should not add script import on client-side", () => {
+    const mdSource = d`
+    ## Hello
+    ![example](./example.png)
+    `;
+
+    const mdPath = "./hello.md";
+
+    const pluginWithResolves = vitePluginMdToHTML({
+      resolveImageLinks: true,
+    });
+
+    pluginWithResolves.configResolved({ build: { ssr: false } });
+    expect(
+      pluginWithResolves.transform(mdSource, mdPath).code
+    ).toMatchInlineSnapshot(`
+      "import mdLink0 from \\"./example.png?url\\";
+      
+      export const attributes = {};
+      export const html = \`<h2>Hello</h2>
+      <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
+      \`;
+      export default html;
+      "
+    `);
   });
 });

--- a/plugin/plugin.spec.ts
+++ b/plugin/plugin.spec.ts
@@ -81,12 +81,12 @@ describe("plugin.transform()", () => {
     pluginWithResolves.configResolved({ build: { ssr: true } });
     expect(pluginWithResolves.transform(mdSource, mdPath).code)
       .toMatchInlineSnapshot(`
-        "import mdLink0 from \\"./example.png?url\\";
-        import mdLink1 from \\"./hello.jpeg?url\\";
+        "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
+        import mdLink1 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/hello.jpeg?url\\";
         
         export const attributes = {};
-        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
-        import \\"./hello.jpeg?url\\";
+        export const html = \`<script type=\\"module\\">import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
+        import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/hello.jpeg?url\\";
         </script><h2>Hello</h2>
         <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
         <img alt=\\"hello\\" src=\\"\${mdLink1}\\" />\`;
@@ -127,10 +127,10 @@ describe("plugin.transform()", () => {
     pluginWithResolves.configResolved({ build: { ssr: true } });
     expect(pluginWithResolves.transform(mdSource, mdPath).code)
       .toMatchInlineSnapshot(`
-        "import mdLink0 from \\"./example.png?url\\";
+        "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
         
         export const attributes = {};
-        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
+        export const html = \`<script type=\\"module\\">import \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
         </script><h2>Hello</h2>
         <p><img src=\\"https://hello.com/example.png\\" alt=\\"example\\">
         <img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
@@ -156,7 +156,7 @@ describe("plugin.transform()", () => {
     expect(
       pluginWithResolves.transform(mdSource, mdPath).code
     ).toMatchInlineSnapshot(`
-      "import mdLink0 from \\"./example.png?url\\";
+      "import mdLink0 from \\"/Users/saurabhdaware/Desktop/projects/vite-plugin-md-to-html/example.png?url\\";
       
       export const attributes = {};
       export const html = \`<h2>Hello</h2>

--- a/plugin/plugin.spec.ts
+++ b/plugin/plugin.spec.ts
@@ -80,16 +80,18 @@ describe("plugin.transform()", () => {
 
     expect(pluginWithResolves.transform(mdSource, mdPath).code)
       .toMatchInlineSnapshot(`
-      "import mdLink0 from \\"./example.png?url\\";
-      import mdLink1 from \\"./hello.jpeg?url\\";
-      
-      export const attributes = {};
-      export const html = \`<h2>Hello</h2>
-      <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
-      <img alt=\\"hello\\" src=\\"\${mdLink1}\\" />\`;
-      export default html;
-      "
-    `);
+        "import mdLink0 from \\"./example.png?url\\";
+        import mdLink1 from \\"./hello.jpeg?url\\";
+        
+        export const attributes = {};
+        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
+        import \\"./hello.jpeg?url\\";
+        </script><h2>Hello</h2>
+        <p><img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
+        <img alt=\\"hello\\" src=\\"\${mdLink1}\\" />\`;
+        export default html;
+        "
+      `);
 
     const pluginWithoutResolves = vitePluginMdToHTML({
       resolveImageLinks: false,
@@ -126,7 +128,8 @@ describe("plugin.transform()", () => {
         "import mdLink0 from \\"./example.png?url\\";
         
         export const attributes = {};
-        export const html = \`<h2>Hello</h2>
+        export const html = \`<script type=\\"module\\">import \\"./example.png?url\\";
+        </script><h2>Hello</h2>
         <p><img src=\\"https://hello.com/example.png\\" alt=\\"example\\">
         <img src=\\"\${mdLink0}\\" alt=\\"example\\"></p>
         <img alt=\\"hello\\" src=\\"https://example.com/hello.jpeg\\" />\`;


### PR DESCRIPTION
This PR adds functionality which will add a fake import in client-side javascript when imageResolution is enabled on SSR.

Vite then reads this fake import and treats it as legit import and moves the assets to dist on client-side.