### PR TITLE
feat: add initial implementation of md function

### DIFF
--- a/plugin/index.d.ts
+++ b/plugin/index.d.ts
@@ -16,3 +16,4 @@ export declare function mdToHTML(
   mdSource: string,
   pluginOptions?: PluginOptions
 ): { html: string; attributes: any };
+export declare function EXPERIMENTAL_md(mdSource: TemplateStringsArray): string;

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,5 @@
 import { vitePluginMdToHTML } from "./vite-plugin.js";
-export { mdToHTML } from "./md-to-html.js";
+export { mdToHTML, EXPERIMENTAL_md } from "./md-to-html.js";
 
 export { vitePluginMdToHTML };
 export default vitePluginMdToHTML;

--- a/plugin/md-to-html.js
+++ b/plugin/md-to-html.js
@@ -1,6 +1,8 @@
 import markdownIt from "markdown-it";
 import fm from "front-matter";
 import markdownItHljs from "markdown-it-highlightjs";
+import dedent from "dedent";
+import { getPluginOptionsGlobal } from "./vite-plugin.js";
 
 /**
  *
@@ -58,4 +60,14 @@ export const mdToHTML = (mdSource, userPluginOptions = {}) => {
     html: markdown.render(fmObject.body),
     attributes: fmObject.attributes,
   };
+};
+
+/**
+ * Currently meant to be used in static-site-generators only
+ *
+ * @param {TemplateStringsArray} mdSource
+ * @returns {string}
+ */
+export const EXPERIMENTAL_md = (mdSource) => {
+  return mdToHTML(dedent(mdSource[0]), getPluginOptionsGlobal()).html;
 };

--- a/plugin/md-to-html.spec.ts
+++ b/plugin/md-to-html.spec.ts
@@ -1,4 +1,4 @@
-import { mdToHTML } from "./md-to-html";
+import { mdToHTML } from ".";
 import { describe, expect, test } from "vitest";
 import { default as d } from "dedent";
 

--- a/plugin/plugin.spec.ts
+++ b/plugin/plugin.spec.ts
@@ -1,7 +1,8 @@
 import path from "path";
-import { vitePluginMdToHTML } from ".";
-import { describe, expect, test } from "vitest";
+import { vitePluginMdToHTML, EXPERIMENTAL_md as md } from ".";
+import { beforeEach, describe, expect, test } from "vitest";
 import { default as d } from "dedent";
+import { clearMemo } from "./vite-plugin";
 
 /**
  * Removes the absolute links from snapshot.
@@ -207,5 +208,44 @@ describe("plugin.transform()", () => {
         export default html;
         "
       `);
+  });
+});
+
+describe("EXPERIMENTAL_md()", () => {
+  beforeEach(() => {
+    clearMemo();
+  });
+
+  test("should use given plugin options", () => {
+    vitePluginMdToHTML({
+      syntaxHighlighting: true,
+    });
+    expect(md`
+      # Hello
+
+      ~~~js
+      const a = 3;
+      ~~~
+    `).toMatchInlineSnapshot(`
+      "<h1>Hello</h1>
+      <pre><code class=\\"hljs language-js\\"><span class=\\"hljs-keyword\\">const</span> a = <span class=\\"hljs-number\\">3</span>;
+      </code></pre>
+      "
+    `);
+  });
+
+  test("should do md to html", () => {
+    expect(md`
+      # Hello
+
+      ~~~js
+      const a = 3;
+      ~~~
+    `).toMatchInlineSnapshot(`
+      "<h1>Hello</h1>
+      <pre><code class=\\"language-js\\">const a = 3;
+      </code></pre>
+      "
+    `);
   });
 });

--- a/plugin/vite-plugin.js
+++ b/plugin/vite-plugin.js
@@ -54,6 +54,8 @@ export default html;
   return jsSrc;
 };
 
+let pluginOptionsGlobal = undefined;
+
 /**
  *
  * @param {PluginOptions} pluginOptions
@@ -61,6 +63,7 @@ export default html;
 export const vitePluginMdToHTML = (pluginOptions) => {
   /** @type {boolean} */
   let isSSRBuild = false;
+  pluginOptionsGlobal = pluginOptions;
   return {
     name: "vite-plugin-md-to-html",
     configResolved(resolvedConfig) {
@@ -96,4 +99,9 @@ export const vitePluginMdToHTML = (pluginOptions) => {
       }
     },
   };
+};
+
+export const getPluginOptionsGlobal = () => pluginOptionsGlobal;
+export const clearMemo = () => {
+  pluginOptionsGlobal = undefined;
 };


### PR DESCRIPTION
In SSGs, you can now use `EXPERIMENTAL_md` function to do inlined markdown to html.

> *Note*
>
> For SSR users, you can also use this though it will run on runtime instead of build-time so you might not want to do it?? but yeah you can if you want. But maybe don't? unless you really want to..?? idk??


E.g. in Abell you can do -
```vue
{{
  import { EXPERIMENTAL_md as md } from 'vite-plugin-md-to-html';
}}
<div>
{{
  md`
  # Hello There!!
  
  ~~~js
  const a = 3;
  ~~~
  `
}}
</div>
```

It uses the configurations you set in `vite.config.ts`